### PR TITLE
Add condition for locations in geo-uniques

### DIFF
--- a/wpcom-geo-uniques/wpcom-geo-uniques.php
+++ b/wpcom-geo-uniques/wpcom-geo-uniques.php
@@ -160,7 +160,11 @@ class WPCOM_Geo_Uniques {
 		}
 
 		$test  = sprintf( 'if ( empty( %s ) ) { return "%s"; }', $global_var, esc_js( self::get_default_location() ) );
-		$test .= sprintf( ' elseif %s', implode( ' elseif ', $checks ) );
+
+		if ( ! empty( $checks ) ) {
+			$test .= sprintf( ' elseif %s', implode( ' elseif ', $checks ) );
+		}
+
 		$test .= sprintf( ' else { return "%s"; }', esc_js( self::get_default_location() ) );
 
 		$user_location = static::run_vary_cache_on_function( $test );


### PR DESCRIPTION
Needs one conditional check on `$checks` variable because it's giving syntax error if the user doesn't define country by `wpcom_geo_add_location()` function.

**Previous:** `if ( empty( %s ) ) { return "%s"; }  elseif  else { return "%s"; }`

**After my patch:** 
**a.** If user added that country then: `if ( empty( %s ) ) { return "%s"; } elseif ( empty( %s ) ) { return "%s"; } else { return "%s"; }`

**b.** If used doesn't added default country then: `if ( empty( %s ) ) { return "%s"; } else { return "%s"; }`